### PR TITLE
Add Laravel 13 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -22,9 +22,11 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         php: [8.4, 8.3]
-        laravel: [12.*, 11.*]
+        laravel: [13.*, 12.*, 11.*]
         stability: [prefer-lowest, prefer-stable]
         include:
+          - laravel: 13.*
+            testbench: 11.*
           - laravel: 12.*
             testbench: 10.*
           - laravel: 11.*

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [8.4, 8.3]
+        php: [8.4, 8.3, 8.2]
         laravel: [13.*, 12.*, 11.*]
         stability: [prefer-lowest, prefer-stable]
         include:
@@ -31,6 +31,9 @@ jobs:
             testbench: 10.*
           - laravel: 11.*
             testbench: 9.*
+        exclude:
+          - laravel: 13.*
+            php: 8.2
     
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}

--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@
 
 ## 📋 Requirements
 
--   PHP 8.1+
--   Laravel 11.x, or 12.x
+-   PHP 8.2+
+-   Laravel 11.x, 12.x, or 13.x
 -   Minimum 256MB memory (recommended 512MB or higher for large files)
 -   File system write permissions for temporary storage
 -   Modern web browser with JavaScript support

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         }
     ],
     "require": {
-        "php": "^8.1|^8.2|^8.3|^8.4",
+        "php": "^8.2",
         "spatie/laravel-package-tools": "^1.16",
         "illuminate/contracts": "^11.0||^12.0||^13.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -25,16 +25,16 @@
     "require": {
         "php": "^8.1|^8.2|^8.3|^8.4",
         "spatie/laravel-package-tools": "^1.16",
-        "illuminate/contracts": "^11.0||^12.0"
+        "illuminate/contracts": "^11.0||^12.0||^13.0"
     },
     "require-dev": {
         "laravel/pint": "^1.14",
         "nunomaduro/collision": "^8.1.1||^7.10.0",
         "larastan/larastan": "^2.9||^3.0",
-        "orchestra/testbench": "^10.0.0||^9.0.0",
-        "pestphp/pest": "^3.0",
-        "pestphp/pest-plugin-arch": "^3.0",
-        "pestphp/pest-plugin-laravel": "^3.0",
+        "orchestra/testbench": "^9.0.0||^10.0.0||^11.0.0",
+        "pestphp/pest": "^3.0||^4.0",
+        "pestphp/pest-plugin-arch": "^3.0||^4.0",
+        "pestphp/pest-plugin-laravel": "^3.0||^4.0",
         "phpstan/extension-installer": "^1.3||^2.0",
         "phpstan/phpstan-deprecation-rules": "^1.1||^2.0",
         "phpstan/phpstan-phpunit": "^1.3||^2.0"


### PR DESCRIPTION
## What's changed

This PR adds support for Laravel 13, released March 17, 2026.

## Changes

- Added `^13.0` to `illuminate/contracts` constraint
- Tightened PHP constraint from `^8.1` to `^8.2` (Laravel 11+ minimum)
- Added `orchestra/testbench ^11.0.0` for testing against Laravel 13
- Updated Pest dependencies to support `^4.0`
- Updated CI matrix: PHP 8.2/8.3/8.4 × Laravel 11/12/13
- Updated README requirements to reflect PHP 8.2+ and Laravel 13

## Compatibility

| Laravel | PHP | Testbench |
|---------|-----|-----------|
| 13.x | 8.3, 8.4 | 11.x |
| 12.x | 8.2, 8.3, 8.4 | 10.x |
| 11.x | 8.2, 8.3, 8.4 | 9.x |