### PR TITLE
Fix workflows triggering on tag pushes

### DIFF
--- a/.github/workflows/fix-php-code-style-issues.yml
+++ b/.github/workflows/fix-php-code-style-issues.yml
@@ -2,6 +2,8 @@ name: Fix PHP code style issues
 
 on:
   push:
+    branches:
+      - '**'
     paths:
       - '**.php'
 

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -2,6 +2,8 @@ name: PHPStan
 
 on:
   push:
+    branches:
+      - '**'
     paths:
       - '**.php'
       - 'phpstan.neon.dist'

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -2,6 +2,8 @@ name: run-tests
 
 on:
   push:
+    branches:
+      - '**'
     paths:
       - '**.php'
       - '.github/workflows/run-tests.yml'


### PR DESCRIPTION
## Problem

When publishing a tag release, the following workflows were incorrectly triggered and failing:

- **Fix PHP code style issues** — fails because `github.head_ref` is empty on tag pushes (it's only populated for pull requests), causing the `actions/checkout` step to fail
- **run-tests** — runs unnecessarily on tag pushes
- **PHPStan** — runs unnecessarily on tag pushes

Tag refs are immutable, so any workflow that attempts to commit back (like the code style fixer) will always fail when triggered by a tag push.

## Solution

Added `branches: - '**'` filter to the `push` trigger on all three affected workflows:

```yaml
on:
  push:
    branches:
      - '**'
    paths:
      - '**.php'
```

This tells GitHub Actions to only run these workflows when pushing to a branch, not when pushing a tag. The `'**'` pattern matches all branch names, so existing behavior on branch pushes is completely unchanged.

## Affected Workflows

| Workflow | File |
|---|---|
| Fix PHP code style issues | `.github/workflows/fix-php-code-style-issues.yml` |
| run-tests | `.github/workflows/run-tests.yml` |
| PHPStan | `.github/workflows/phpstan.yml` |

## Testing

Push a tag (e.g. `git tag v1.x.x && git push --tags`) — none of the above workflows should trigger. Branch pushes with PHP file changes continue to work as before.