### PR TITLE
fix: add pull_request triggers to CI workflows

### DIFF
--- a/.github/workflows/fix-php-code-style-issues.yml
+++ b/.github/workflows/fix-php-code-style-issues.yml
@@ -17,6 +17,7 @@ jobs:
   php-code-styling:
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
 
     steps:
       - name: Checkout code

--- a/.github/workflows/fix-php-code-style-issues.yml
+++ b/.github/workflows/fix-php-code-style-issues.yml
@@ -6,6 +6,9 @@ on:
       - '**'
     paths:
       - '**.php'
+  pull_request:
+    paths:
+      - '**.php'
 
 permissions:
   contents: write

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -8,6 +8,11 @@ on:
       - '**.php'
       - 'phpstan.neon.dist'
       - '.github/workflows/phpstan.yml'
+  pull_request:
+    paths:
+      - '**.php'
+      - 'phpstan.neon.dist'
+      - '.github/workflows/phpstan.yml'
 
 jobs:
   phpstan:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,6 +10,13 @@ on:
       - 'phpunit.xml.dist'
       - 'composer.json'
       - 'composer.lock'
+  pull_request:
+    paths:
+      - '**.php'
+      - '.github/workflows/run-tests.yml'
+      - 'phpunit.xml.dist'
+      - 'composer.json'
+      - 'composer.lock'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -36,7 +43,6 @@ jobs:
         exclude:
           - laravel: 13.*
             php: 8.2
-    
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 


### PR DESCRIPTION
## Summary

- `run-tests.yml`, `phpstan.yml`, and `fix-php-code-style-issues.yml` were only triggering on `push` events
- Added `pull_request:` triggers with matching path filters to all three workflows
- Workflows will now run on PRs so tests, static analysis, and code style checks are visible as required status checks

## Test plan

- [ ] Open a test PR and verify all three workflows appear as checks
- [ ] Confirm tests pass, PHPStan reports no errors, and Pint fixes/commits style issues